### PR TITLE
Efficiency fix 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,130 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+*.sh
+.DS_Store

--- a/action_auditor.py
+++ b/action_auditor.py
@@ -1,5 +1,6 @@
 from github_wrapper import GHWrapper
 from lib.logger import AuditLogger
+from pathlib import Path
 import re
 
 gh = GHWrapper()
@@ -22,5 +23,10 @@ def check_usernames(username_list):
             AuditLogger.warning(f"Security Issue: Supply chain. {username} was renamed but used in workflows. Signup the username at https://github.com to make sure.")
 
 def action_audit():
-    usernames = read_actions_file()
-    check_usernames(usernames)
+    if Path('actions.txt').exists():
+        usernames = read_actions_file()
+        check_usernames(usernames)
+        Path('actions.txt').unlink()
+    else:
+        AuditLogger.info("No actions.txt file to scan. Supply chain scan complete.")
+

--- a/main.py
+++ b/main.py
@@ -7,8 +7,6 @@ from github_wrapper import GHWrapper
 from lib.logger import AuditLogger
 
 
-gh = GHWrapper()
-
 """
 Input:
    repo_dict - dictionary defining repo information
@@ -34,7 +32,9 @@ def main():
                         help='Type of entity that is being scanned.')
     parser.add_argument('input',help='Org, user or repo name (owner/name)')
     args = parser.parse_args()
-
+    
+    gh = GHWrapper()
+    
     target_type = args.type #repo, org, or user
     target_input = args.input #can be repo url, or a username for org/user
     


### PR DESCRIPTION
## Fixes

* Moves GitHub Wrapper creation after the arguments so users can run `-h` without PAT requirement. 
* Checks for `actions.txt` file before running action auditor to prevent file not found crash.
* Removes `actions.txt` after scan. This will prevent users from getting false positive if a stale account was found is past scans.